### PR TITLE
0.1.15 update of vagrant, chefdk, and terraform

### DIFF
--- a/.kitchen.yml
+++ b/.kitchen.yml
@@ -4,7 +4,8 @@ driver:
 
 provisioner:
   name: chef_zero
-  require_chef_omnibus: 12.21.4
+  #require_chef_omnibus: 12.21.4
+  require_chef_omnibus: 13.5.3
 
   # You may wish to disable always updating cookbooks in CI or other testing environments.
   # For example:
@@ -16,7 +17,7 @@ verifier:
   name: inspec
 
 platforms:
-  - name: ubuntu-16.10
+  - name: ubuntu-16.04
 
 suites:
   - name: default

--- a/Berksfile
+++ b/Berksfile
@@ -6,4 +6,5 @@ metadata
 # having to hack in my own branches until the main repo updates
 cookbook 'virtualbox', git: 'https://github.com/dayne/virtualbox-cookbook'
 cookbook 'terraform', git: 'https://github.com/rosstimson/chef-terraform'
-cookbook 'chef-dk', git: 'https://github.com/RoboticCheese/chef-dk-chef'
+cookbook 'atom', git: 'git@github.com:dayne/chef-atom.git', branch: 'relaxhomebrew'
+#cookbook 'chef-dk', git: 'https://github.com/dayne/chef-dk-chef', branch: 'jdh-updatings'

--- a/Berksfile.lock
+++ b/Berksfile.lock
@@ -1,7 +1,8 @@
 DEPENDENCIES
-  chef-dk
-    git: https://github.com/RoboticCheese/chef-dk-chef
-    revision: 5d4a714a6c8190b632129c1da3a986e02519f370
+  atom
+    git: git@github.com:dayne/chef-atom.git
+    revision: 2fd6963345a447cc53977f52a5478cfe62d4094e
+    branch: relaxhomebrew
   d_devbox
     path: .
     metadata: true
@@ -14,28 +15,18 @@ DEPENDENCIES
 
 GRAPH
   apache2 (5.0.1)
-  apt (6.1.4)
-  apt-chef (2.0.1)
-    apt (>= 0.0.0)
+  apt (3.0.0)
   ark (2.2.1)
     build-essential (>= 0.0.0)
     seven_zip (>= 0.0.0)
     windows (>= 0.0.0)
-  atom (0.2.0)
-    apt (>= 0.0.0)
-    homebrew (>= 0.0.0)
+  atom (0.2.1)
+    apt (~> 3.0)
+    homebrew (< 5.0.0)
   build-essential (8.0.3)
     mingw (>= 1.1)
     seven_zip (>= 0.0.0)
-  chef-dk (3.1.1)
-    apt-chef (~> 2.0)
-    chocolatey (~> 1.0)
-    dmg (~> 3.0)
-    homebrew (~> 2.1)
-    yum-chef (~> 2.0)
-  chocolatey (1.2.1)
-    windows (>= 1.38)
-  d_devbox (0.1.13)
+  d_devbox (0.1.15)
     atom (>= 0.2.0)
     docker (>= 2.15.25)
     habitat (>= 0.3.0)
@@ -44,11 +35,10 @@ GRAPH
     vagrant (>= 0.7.0)
     virtualbox (>= 2.0.0)
   dmg (3.1.1)
-  docker (2.16.0)
+  docker (2.16.4)
   golang (1.7.0)
-  habitat (0.34.0)
-  homebrew (2.1.2)
-    build-essential (>= 2.1.2)
+  habitat (0.38.0)
+  homebrew (4.2.0)
   mingw (2.0.1)
     seven_zip (>= 0.0.0)
   ohai (5.2.0)
@@ -69,8 +59,6 @@ GRAPH
     dmg (>= 0.0.0)
     windows (>= 0.0.0)
     yum (~> 3.1)
-  windows (3.1.3)
+  windows (3.3.0)
     ohai (>= 4.0.0)
   yum (3.13.0)
-  yum-chef (2.0.1)
-    yum (>= 3.2)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,10 @@
 =======
 ## Unreleased
 
+## 0.1.15 - 2017-10-03
+* update terraform (0.10.8), chefdk (2.3.4-1), vagrant (2.0.1)
+* pull in branchs atom to get out from under old homebrew dep.
+
 ## 0.1.14 - 2017-10-03
 * minor update to latest version of dependancies (berks update)
 

--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -1,11 +1,13 @@
-default['vagrant']['version'] = '2.0.0'
-default['terraform']['version'] = '0.10.7'
-default['chefdk']['version'] = '1.6.1'
+default['vagrant']['version'] = '2.0.1'
+default['terraform']['version'] = '0.10.8'
+default['chefdk']['version'] = '2.3.4-1'
+
+default['chefdk']['url'] = 'https://packages.chef.io/files/stable/chefdk/2.3.4/ubuntu/16.04/chefdk_2.3.4-1_amd64.deb'
+default['chefdk']['checksum'] = 'ff7124bfd4ad4b7351177df89b3986661f95e14df2dfb5b9ea6b0af247c2c07d'
+# https://packages.chef.io/files/stable/chefdk/1.6.1/ubuntu/16.04/chefdk_1.6.1-1_amd64.deb'
+# 'ffa2c4e1cd624b86a28a23e9ad13b6b6a7e7e651ef22b3dc55fd56427775ad1c'
+
 node.default['gitkraken']['version'] = '3.1.0'
-
-default['chefdk']['url'] = 'https://packages.chef.io/files/stable/chefdk/1.6.1/ubuntu/16.04/chefdk_1.6.1-1_amd64.deb'
-default['chefdk']['checksum'] = 'ffa2c4e1cd624b86a28a23e9ad13b6b6a7e7e651ef22b3dc55fd56427775ad1c'
-
 node.default['gitkraken']['url'] = \
            'http://n1nj4net-public.s3-website-us-west-2.amazonaws.com/gitkraken-amd64-3.1.0.deb'
            # aws s3 cp gitkraken-amd64-2.3.3.deb s3://n1nj4net-public/ --acl public-read

--- a/metadata.rb
+++ b/metadata.rb
@@ -5,7 +5,7 @@ license 'MIT'
 description 'Installs/Configures a development box for Chef/Kitchen/Cloud'
 long_description 'Installs/Configures Chefdk, VirtualBox, Packer, Vagrant,
     Atom editor, Habitat, and other key tools needed to get started hacking.'
-version '0.1.14'
+version '0.1.15'
 
 supports 'ubuntu'
 issues_url 'https://github.com/dayne/d_devbox/issues' if respond_to?(:issues_url)


### PR DESCRIPTION
* update terraform (0.10.8), chefdk (2.3.4-1), vagrant (2.0.1)
* pull in branches atom to get out from under old homebrew dep.